### PR TITLE
Updated to use the base amazon-cognito-identity-js package.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -2,7 +2,7 @@
 var AWS = require('aws-sdk');
 var util = require('util');
 var passport = require('passport-strategy');
-var CognitoSDK = require('amazon-cognito-identity-js-node');
+var CognitoSDK = require('amazon-cognito-identity-js');
 
 AWS.CognitoIdentityServiceProvider.AuthenticationDetails = CognitoSDK.AuthenticationDetails;
 AWS.CognitoIdentityServiceProvider.CognitoUserPool = CognitoSDK.CognitoUserPool;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/kndt84/passport-cognito#readme",
   "dependencies": {
-    "amazon-cognito-identity-js-node": "0.0.1",
+    "amazon-cognito-identity-js": "1.21.0",
     "aws-sdk": "^2.6.9",
     "jsbn": "^0.1.0",
     "moment": "^2.15.1",


### PR DESCRIPTION
We ran into a problem with the current passport-cognito package and its use of the amazon-cognito-identity-js fork that's specifically for node.  It's a really old fork, and it actually logs the access tokens to the console log, which we consider a security issue.

We tested passport-cognito using the basic amazon-cognito-identity-js package (the current version runs fine on a node server, it just uses an in-memory store for the storage), and it works fine.  So this pull request just switched passport-cognito to use the core amazon-cognito-identity-js package instead of the node fork.