### PR TITLE
Scope variables to fix `Improper Authorization` security issue

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -92,9 +92,9 @@ CognitoStrategy.prototype.authenticate = function(req, options) {
   cognitoUser.authenticateUser(authenticationDetails, {
     onSuccess: function (session) {
 
-      accessToken = session.getAccessToken().getJwtToken();
-      idToken = session.getIdToken().getJwtToken();
-      refreshToken = session.getRefreshToken().getToken();
+      var accessToken = session.getAccessToken().getJwtToken();
+      var idToken = session.getIdToken().getJwtToken();
+      var refreshToken = session.getRefreshToken().getToken();
 
       if (!accessToken || !idToken) {
         return self.fail({ message: options.badRequestMessage || 'Missing token' }, 400);


### PR DESCRIPTION
Scoping the variables properly fixes the issue described in [Improper Authorization #38](https://github.com/kndt84/passport-cognito/issues/38). This issue causes a race condition where simultaneous authenticated users may receive authorization tokens for a different user. The package is currently marked to have a [critical security issue](https://www.npmjs.com/advisories/1443) by npm. 